### PR TITLE
Added ability to get api urlBase

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -391,6 +391,10 @@ module
     this.setUrlBase = function(url) {
       urlBase = url;
     };
+    
+    this.getUrlBase = function() {
+      return urlBase;
+    };
 
     this.$get = ['$resource', function($resource) {
       return function(url, params, actions) {


### PR DESCRIPTION
In a case you need to call the api directly through another service. We can use this service provider as the primary url to reference.
